### PR TITLE
Proposed fixes for issues #53, #54, #55, and #68

### DIFF
--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -576,7 +576,7 @@ When the TEEP Broker receives a request to contact the TAM for an Untrusted Appl
 install a TA, a list of TAMs may be provided. The TEEP Broker selects a single TAM that
 is consistent with the list of trusted TAMs (trust anchors) provisioned on the device.
 For any Untrusted Application, there should be only a single TAM for the TEEP Broker to contact.
-This is also the case when a Untrusted Application uses multiple TAs, or when one TA depends on
+This is also the case when an Untrusted Application uses multiple TAs, or when one TA depends on
 anther TA in a software dependency (see section TBD). The reason is that the SP should
 provide each TAM that it places in the Untrusted Application's manifest all the TAs that the app
 requires. There is no benefit to going to multiple different TAMs, and there is no
@@ -600,7 +600,7 @@ multiple TAs running. This requires more discussion.]
 
 In TEEP, there is an explicit relationship and dependence between the Untrusted Application
 in the REE and one or more TAs in the TEE, as shown in {{notionalarch2}}.
-From the perspective of a device user, a Untrusted Application that uses one or more TA's in a TEE
+From the perspective of a device user, an Untrusted Application that uses one or more TA's in a TEE
 appears no different from any other Untrusted Application in the REE. However, the way
 the Untrusted Application and its corresponding TA's are packaged, delivered, and installed on
 the device can vary. The variations depend on whether the Untrusted Application and TA are bundled

--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -553,7 +553,7 @@ specific TA. The TA itself is digitally signed, protecting its integrity, but th
 signature also links the TA back to the signer. The signer is usually the SP, but in
 some cases may be another party that the SP trusts. The SP selects one or more TAMs
 through which to offer their service, and communicates the information of the service
-and the specific client apps and TAs to the TAM.
+and the specific Untrusted Applications and TAs to the TAM.
 
 The SP chooses TAMs based upon the markets into which the TAM can provide access. There
 may be TAMs that provide services to specific types of mobile devices, or mobile device
@@ -569,13 +569,13 @@ for enterprise applications or SPs serving a closed community. For broad public 
 there will likely be multiple TAMs in the manifest - one servicing one brand of mobile
 device and another servicing a different manufacturer, etc. Because different devices
 and different manufacturers trust different TAMs, the manifest will include different
-TAMs that support this SP's client app and TA. Multiple TAMs allow the SP to provide
+TAMs that support this SP's Untrusted Application and TA. Multiple TAMs allow the SP to provide
 thier service and this app (and TA) to multiple different devices.
 
 When the TEEP Broker receives a request to contact the TAM for an Untrusted Application in order to
 install a TA, a list of TAMs may be provided. The TEEP Broker selects a single TAM that
 is consistent with the list of trusted TAMs (trust anchors) provisioned on the device.
-For any client app, there should be only a single TAM for the TEEP Broker to contact.
+For any Untrusted Application, there should be only a single TAM for the TEEP Broker to contact.
 This is also the case when a Untrusted Application uses multiple TAs, or when one TA depends on
 anther TA in a software dependency (see section TBD). The reason is that the SP should
 provide each TAM that it places in the Untrusted Application's manifest all the TAs that the app
@@ -598,14 +598,14 @@ multiple TAs running. This requires more discussion.]
 
 ## Untrusted Apps, Trusted Apps, and Personalization Data
 
-In TEEP, there is an explicit relationship and dependence between the client app
+In TEEP, there is an explicit relationship and dependence between the Untrusted Application
 in the REE and one or more TAs in the TEE, as shown in {{notionalarch2}}.
-From the perspective of a device user, a client app that uses one or more TA's in a TEE
+From the perspective of a device user, a Untrusted Application that uses one or more TA's in a TEE
 appears no different from any other Untrusted Application in the REE. However, the way
-the client app and its corresponding TA's are packaged, delivered, and installed on
-the device can vary. The variations depend on whether the client app and TA are bundled
+the Untrusted Application and its corresponding TA's are packaged, delivered, and installed on
+the device can vary. The variations depend on whether the Untrusted Application and TA are bundled
 together or are provided separately, and this has implications to the management of
-the TAs in the TEE. In addition to the client app and TA, the TA and/or TEE may require
+the TAs in the TEE. In addition to the Untrusted Application and TA, the TA and/or TEE may require
 some additional data to personalize the TA to the service provider or the device user.
 This personalization data is dependent on the TEE, the TA and the SP; an example of
 personalization data might be username and password of the device user's account with
@@ -634,7 +634,7 @@ In order to better understand these cases, it is helpful to review actual implem
 In Intel Software Guard Extensions (SGX), the Untrsuted Application and TA are typically bound into the
 same binary (Case 2). The TA is compiled into the Untrusted Application binary using SGX tools, and
 exists in the binary as a shared library (.so or .dll). The Untrusted Application loads the TA into
-an SGX enclave when the client needs the TA. This organization makes it easy to maintain
+an SGX enclave when the Untrusted Application needs the TA. This organization makes it easy to maintain
 compatibility between the Untrusted Application and the TA, since they are updated together. It is
 entirely possible to create an Untrusted Application that loads an external TA into an SGX enclave and
 use that TA (Case 3). In this case, the Untrusted Application would require a reference to an external
@@ -663,7 +663,7 @@ This section defines TEEP support for the three different cases for delivery of 
 App, TA, and personalization data.
 
 [Note: discussion of format of this single binary, and who/what is responsible for splitting
-these things apart, and installing the client app into the REE, the TA into the TEE, and the
+these things apart, and installing the Untrusted Application into the REE, the TA into the TEE, and the
 personalization data into the TEE or TA. Obviously the decryption must be done by the TEE
 but this may not be supported by all TAs.]
 

--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -452,7 +452,7 @@ all components are further explained in the following paragraphs.
     to pass the messages from the TAM to TEEs in the device.  This
     calls for a component in the REE that Untrusted Applications can use
     to pass messages to TEEs.  The TEEP Broker is thus an application
-    in the REE or software library that can relay messages from a Client
+    in the REE or software library that can relay messages from an Untrusted
     Application to a TEE in the device.  A device usually comes with
     only one active TEE.  A TEE may provide such a
     Broker to the device manufacturer to be bundled in devices.  Such
@@ -647,8 +647,8 @@ be in use at this time, since such a construction would required a special insta
 program and SGX TA to recieve the encrypted binary, decrypt it, separate it into the
 three different elements, and then install all three. This installation is complex,
 because the Untrusted Application decrypted inside the TEE must be passed out of the TEE to an
-installer in the REE which would install the Untrusted Application; this assumes that the Client
-App binary includes the TA code also, otherwise there is a significant problem in getting
+installer in the REE which would install the Untrusted Application; this assumes that the Untrusted
+Application binary includes the TA code also, otherwise there is a significant problem in getting
 the SGX encalve code (the TA) from the TEE, through the installer and into the Untrusted Application
 in a trusted fashion. Finally, the personalization data would need to be sent out of the
 TEE (encrypted in an SGX encalve-to-enclave manner) to the REE's installation app, which
@@ -659,8 +659,8 @@ and does not have direct communication to one another.
 [NOTE: Need to add an equivalent discussion for an ARM/TZ implementation]  
 
 ## TEEP Architectural Support for Untrusted Application, TA, and Personalization Data Delivery
-This section defines TEEP support for the three different cases for delivery of the Client
-App, TA, and personalization data.
+This section defines TEEP support for the three different cases for delivery of the Untrusted
+Application, TA, and personalization data.
 
 [Note: discussion of format of this single binary, and who/what is responsible for splitting
 these things apart, and installing the Untrusted Application into the REE, the TA into the TEE, and the
@@ -721,11 +721,11 @@ SW      |    |   |                             |       |
 two applications: 1) an Untrusted Application; 2) a TA
 that provides some security functions to be run inside
 a TEE. At step 2, the application developer uploads the
-Untrusted Application (2a) to an Application Store. The Client
+Untrusted Application (2a) to an Application Store. The Untrusted
 Application may optionally bundle the TA binary. Meanwhile,
 the application developer may provide its TA to a TAM provider
 that will be managing the TA in various devices. 3. A user
-will go to an Application Store to download the Client
+will go to an Application Store to download the Untrusted
 Application. The Untrusted Application will trigger TA installation
 by initiating communication with a TAM. This is the step 4. The Untrusted Application
 will get messages from TAM, and interacts with device
@@ -735,33 +735,33 @@ The following diagram shows a system diagram about
 the entity relationships between CAs, TAMs, SPs and devices.
 
 ~~~~
-        ------- Message Protocol  -----
-        |                             |
-        |                             |
- --------------------           ---------------   ----------
- |  REE   |  TEE    |           |    TAM      |   |  SP    |
- |  ---   |  ---    |           |    ---      |   |  --    |
- |        |         |           |             |   |        |
- | Client | TEEP    |           |      TA     |   |  TA    |
- |  Apps  | Agent   |           |     Mgmt    |   |        |
- |   |    |         |           |             |   |        |
- |   |    |  TAs    |           |             |   |        |
- |  TEEP  |         |           |             |   |        |
- | Broker | List of |           |  List of    |   |        |
- |        | Trusted |           |  Trusted    |   |        |
- |        |  TAM/SP |           |   FW/TEE    |   |        |
- |        |   CAs   |           |    CAs      |   |        |
- |        |         |           |             |   |        |
- |        |TEE Key/ |           |  TAM Key/   |   |SP Key/ |
- |        |  Cert   |           |    Cert     |   | Cert   |
- |        | FW Key/ |           |             |   |        |
- |        |  Cert   |           |             |   |        |
- --------------------           ---------------   ----------
-              |                        |              |
-              |                        |              |
-        -------------              ----------      ---------
-        | TEE CA    |              | TAM CA |      | SP CA |
-        -------------              ----------      ---------
+           ------- Message Protocol  -----
+           |                             |
+           |                             |
+ -----------------------           ---------------   ----------
+ |  REE      |  TEE    |           |    TAM      |   |  SP    |
+ |  ---      |  ---    |           |    ---      |   |  --    |
+ |           |         |           |             |   |        |
+ | Untrusted | TEEP    |           |      TA     |   |  TA    |
+ |  Apps     | Agent   |           |     Mgmt    |   |        |
+ |   |       |         |           |             |   |        |
+ |   |       |  TAs    |           |             |   |        |
+ |  TEEP     |         |           |             |   |        |
+ | Broker    | List of |           |  List of    |   |        |
+ |           | Trusted |           |  Trusted    |   |        |
+ |           |  TAM/SP |           |   FW/TEE    |   |        |
+ |           |   CAs   |           |    CAs      |   |        |
+ |           |         |           |             |   |        |
+ |           |TEE Key/ |           |  TAM Key/   |   |SP Key/ |
+ |           |  Cert   |           |    Cert     |   | Cert   |
+ |           | FW Key/ |           |             |   |        |
+ |           |  Cert   |           |             |   |        |
+ -----------------------           ---------------   ----------
+                 |                        |              |
+                 |                        |              |
+           -------------              ----------      ---------
+           | TEE CA    |              | TAM CA |      | SP CA |
+           -------------              ----------      ---------
 ~~~~
 {: #keys title="Keys"}
 
@@ -1029,7 +1029,7 @@ and TAM interaction to install all required TAs that an Untrusted Application
 depends. An Untrusted Application may have a metadata file that describes
 the TAs it depends on and the associated TAM that each TA installation
 goes to use. The REE Application Installer can inspect the
-application metadata file and installs TAs on behalf of the Client
+application metadata file and installs TAs on behalf of the Untrusted
 Application without requiring the Untrusted Application to run first.
 
 This interface for Untrusted Applications or Application Installers may be
@@ -1385,7 +1385,7 @@ device.
 
 ## Broker Trust Model
 
-A TEEP Broker could be malware in the vulnerable REE.  A Client
+A TEEP Broker could be malware in the vulnerable REE.  An Untrusted
 Application will connect its TAM provider for required TA
 installation.  It gets command messages from the TAM, and passes the
 message to the Broker.

--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -261,7 +261,7 @@ The following terms are used:
 
   - Root-of-Trust (RoT): A hardware or software component in a device
     that is inherently trusted to perform a certain security-critical
-    function. A RoT should be secure by design, small, and protected
+    function. A RoT should ideally be secure by design, small, and protected
     by hardware against modification or interference. Examples of
     RoTs include software/firmware measurement and verification using
     a Trust Anchor (RoT for Verification), provide signed assertions
@@ -330,7 +330,7 @@ input protection.
 
 For better security of authentication, a device may store its
 sensitive authentication keys inside a TEE, providing
-hardware-protected security key strength and trusted code execution.
+TEE-protected security key strength and trusted code execution.
 
 ## Internet of Things
 

--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -70,10 +70,10 @@ informative:
 
 --- abstract
 
-A Trusted Execution Environment (TEE) is designed to provide a
-hardware-isolation mechanism to separate a regular operating system
-from security-sensitive application components.
-
+A Trusted Execution Environment (TEE) is an environment that
+enforces that only authorized code can execute with that environment,
+and that any data used by such code cannot be read or tampered with
+by any code outside that environment.
 This architecture document motivates the design and standardization
 of a protocol for managing the lifecycle of trusted applications
 running inside a TEE.
@@ -96,21 +96,22 @@ concern to its owner, but a compromise of a banking application raises
 even greater concerns.
 
 The Trusted Execution Environment (TEE) concept is designed to execute
-applications in a protected environment that separates applications
-inside the TEE from the regular operating system and from other
-applications on the device. This separation reduces the possibility
+applications in a protected environment that enforces that only authorized 
+code can execute with that environment, and that any data used by such code 
+cannot be read or tampered with by any code outside that environment,
+including a commodity operating system (if present).
+
+This separation reduces the possibility
 of a successful attack on application components and the data contained inside the
 TEE. Typically, application components are chosen to execute inside a TEE because
 those application components perform security sensitive operations or operate on
 sensitive data. An application component running inside a TEE is referred to as a
-Trusted Application (TA), while a normal application running in the
-regular operating system is referred to as an Untrusted Application
-(UA).
+Trusted Application (TA), while an application running outside any TEE
+is referred to as an Untrusted Application (UA).
 
-The TEE uses hardware to enforce protections on the TA and its data, but
+The TEE typically uses hardware to enforce protections on the TA and its data, but
 also presents a more limited set of services to applications inside the
-TEE than is normally available to UA's running in the normal operating
-system.
+TEE than is normally available to Untrusted Applications.
 
 But not all TEEs are the same, and different vendors may have different
 implementations of TEEs with different security properties, different
@@ -170,9 +171,8 @@ in all capitals, as shown here.
 
 The following terms are used:
 
-  - Client Application: An application running in a Rich Execution
+  - Untrusted Application: An application running in a Rich Execution
     Environment, such as an Android, Windows, or iOS application.
-    We sometimes refer to this as the 'Client App'.
 
   - Device: A physical piece of hardware that hosts a TEE along with
     a Rich Execution Environment. A Device contains a default list
@@ -188,8 +188,8 @@ The following terms are used:
   - Rich Execution Environment (REE): An environment that is provided
     and governed by a typical OS (e.g., Linux, Windows, Android, iOS),
     potentially in conjunction with other supporting operating systems
-    and hypervisors; it is outside of the TEE. This environment and
-    applications running on it are considered un-trusted.
+    and hypervisors; it is outside of any TEE. This environment and
+    applications running on it are considered untrusted.
 
   - Service Provider (SP): An entity that wishes to provide a service
     on Devices that requires the use of one or more Trusted Applications.
@@ -406,7 +406,7 @@ all components are further explained in the following paragraphs.
     The TAM performs its management of TA's through  an
     interaction with a Device's TEEP Broker. As shown in
     #notionalarch, the TAM cannot directly contact a Device, but must
-    wait for a the TEEP Broker or a Client Application to contact
+    wait for a the TEEP Broker or an Untrusted Application to contact
     the TAM requesting a particular service. This architecture is
     intentional in order to accommodate network and application firewalls
     that normally protect user and enterprise devices from arbitrary
@@ -447,10 +447,10 @@ all components are further explained in the following paragraphs.
     on behalf of a TEE, but merely is responsible for relaying messages from
     the TAM to the TEE, and for returning the TEE's responses to the TAM.
 
-    A Client Application is expected to communicate with a TAM to
-    request TAs that it needs to use.  The Client Application needs
+    An Untrusted Application is expected to communicate with a TAM to
+    request TAs that it needs to use.  The Untrusted Application needs
     to pass the messages from the TAM to TEEs in the device.  This
-    calls for a component in the REE that Client Applications can use
+    calls for a component in the REE that Untrusted Applications can use
     to pass messages to TEEs.  The TEEP Broker is thus an application
     in the REE or software library that can relay messages from a Client
     Application to a TEE in the device.  A device usually comes with
@@ -483,9 +483,9 @@ all components are further explained in the following paragraphs.
 There is nothing prohibiting a device from implementing multiple TEEs. In
 addition, some TEEs (for example, SGX) present themselves as separate containers
 within memory without a controlling manager within the TEE. In these cases,
-the rich operating system hosts multiple TEEP brokers, where each broker manages
+the Rich Execution Environment hosts multiple TEEP brokers, where each broker manages
 a particular TEE or set of TEEs. Enumeration and access to the appropriate
-broker is up to the rich OS and the applications. Verification that the correct TA
+TEEP Broker is up to the Rich Execution Environment and the Untrusted Applications. Verification that the correct TA
 has been reached then becomes a matter of properly verifying TA attestations,
 which are unforgeable. The multiple TEE approach is shown in the diagram below.
 For brevity, TEEP Broker 2 is shown interacting with only one TAM and UA, but
@@ -545,8 +545,8 @@ information from the TEEP Broker to which it communicates.
 ## Multiple TAMs and Relationship to TAs
 
 As shown in {{notionalarch2}}, the TEEP Broker provides connections from the TEE and
-the Client App to one or more TAMs. The selection of which TAM to communicate with is
-dependent on information from the Client App and is directly related to the TA.
+the Untrusted Application to one or more TAMs. The selection of which TAM to communicate with is
+dependent on information from the Untrusted Application and is directly related to the TA.
 
 When a SP offers a service which requires a TA, the SP associates that service with a
 specific TA. The TA itself is digitally signed, protecting its integrity, but the
@@ -562,8 +562,8 @@ motivated to utilize multiple TAMs for its service in order to maximize market p
 and availability on multiple types of devices. This likely means that the same service
 will be available through multiple TAMs.
 
-When the SP publishes the Client App to an app store or other app repositories, the SP
-binds the Client App with a manifest that identifies what TAMs can be contacted for
+When the SP publishes the Untrusted Application to an app store or other app repositories, the SP
+binds the Untrusted Application with a manifest that identifies what TAMs can be contacted for
 the TA. In some situations, an SP may use only a single TAM - this is likely the case
 for enterprise applications or SPs serving a closed community. For broad public apps,
 there will likely be multiple TAMs in the manifest - one servicing one brand of mobile
@@ -572,13 +572,13 @@ and different manufacturers trust different TAMs, the manifest will include diff
 TAMs that support this SP's client app and TA. Multiple TAMs allow the SP to provide
 thier service and this app (and TA) to multiple different devices.
 
-When the TEEP Broker receives a request to contact the TAM for a Client App in order to
+When the TEEP Broker receives a request to contact the TAM for an Untrusted Application in order to
 install a TA, a list of TAMs may be provided. The TEEP Broker selects a single TAM that
 is consistent with the list of trusted TAMs (trust anchors) provisioned on the device.
 For any client app, there should be only a single TAM for the TEEP Broker to contact.
-This is also the case when a Client App uses multiple TAs, or when one TA depends on
+This is also the case when a Untrusted Application uses multiple TAs, or when one TA depends on
 anther TA in a software dependency (see section TBD). The reason is that the SP should
-provide each TAM that it places in the Client App's manifest all the TAs that the app
+provide each TAM that it places in the Untrusted Application's manifest all the TAs that the app
 requires. There is no benefit to going to multiple different TAMs, and there is no
 need for a special TAM to be contacted for a specific TA.
 
@@ -589,19 +589,19 @@ atttestation signatures as well. It is highly unlikely that a set of TAs would u
 different proprietary attestation mechanisms since a TEE is likley to support only
 one such proprietary scheme.]
 
-[Note: This situation gets more complex in situations where a Client App expects
+[Note: This situation gets more complex in situations where an Untrusted Application expects
 another application or a device to already have a specific TA installed. This
 situation does not occur with SGX, but could occur in situations where the secure
 world maintains an trusted operating system and runs an entire trusted system with
 multiple TAs running. This requires more discussion.]
 
 
-## Client Apps, Trusted Apps, and Personalization Data
+## Untrusted Apps, Trusted Apps, and Personalization Data
 
 In TEEP, there is an explicit relationship and dependence between the client app
 in the REE and one or more TAs in the TEE, as shown in {{notionalarch2}}.
 From the perspective of a device user, a client app that uses one or more TA's in a TEE
-appears no different from any other untrusted application in the REE. However, the way
+appears no different from any other Untrusted Application in the REE. However, the way
 the client app and its corresponding TA's are packaged, delivered, and installed on
 the device can vary. The variations depend on whether the client app and TA are bundled
 together or are provided separately, and this has implications to the management of
@@ -614,30 +614,30 @@ personalization data must be encrypted to preserve the confidentiality of potent
 sensitive data contained within it. Other than this requirement to support confidentiality,
 TEEP place no limitations or requirements on the personalization data.
 
-There are three possible cases for bundling of the Client App, TA, and personalization data:
+There are three possible cases for bundling of the Untrusted Application, TA, and personalization data:
 
-  1. The Client App, TA, and personalization data are all bundled together in a single
+  1. The Untrusted Application, TA, and personalization data are all bundled together in a single
      package by the SP and provided to the TEEP Broker through the TAM.
 
-  2. The Client App and the TA are bundled together in a single binary, which the TAM or
+  2. The Untrusted Application and the TA are bundled together in a single binary, which the TAM or
      a publicly accessible app store maintains in repository, and the personalization data
      is separately provided by the SP. In this case, the personalization data is collected
      by the TAM and included in the InstallTA message to the TEEP Broker.
 
-  3. All components are independent. The device user installs the Client App through some
+  3. All components are independent. The device user installs the Untrusted Application through some
      independent or device-specific mechanism, and the TAM provides the TA and personalization
      data from the SP. Delivery of the TA and personalization data may be combined or separate.
 
 ## Examples of Application Delivery Mechanisms in Existing TEEs
 In order to better understand these cases, it is helpful to review actual implementations of TEEs and their application delivery mechanisms.
 
-In Intel Software Guard Extensions (SGX), the Client App and TA are typically bound into the
-same binary (Case 2). The TA is compiled into the Client App binary using SGX tools, and
-exists in the binary as a shared library (.so or .dll). The Client App loads the TA into
+In Intel Software Guard Extensions (SGX), the Untrsuted Application and TA are typically bound into the
+same binary (Case 2). The TA is compiled into the Untrusted Application binary using SGX tools, and
+exists in the binary as a shared library (.so or .dll). The Untrusted Application loads the TA into
 an SGX enclave when the client needs the TA. This organization makes it easy to maintain
-compatibility between the Client App and the TA, since they are updated together. It is
-entirely possible to create a Client App that loads an external TA into an SGX enclave and
-use that TA (Case 3). In this case, the Client App would require a reference to an external
+compatibility between the Untrusted Application and the TA, since they are updated together. It is
+entirely possible to create an Untrusted Application that loads an external TA into an SGX enclave and
+use that TA (Case 3). In this case, the Untrusted Application would require a reference to an external
 file or download such a file dynamically, place the contents of the file into memory, and
 load that as a TA. Obviously, such file or downloaded content must be properly formatted
 and signed for it to be accepted by the SGX TEE. In SGX, for Case 2 and Case 3, the
@@ -646,19 +646,19 @@ started. Although Case 1 is possible with SGX, there are no instances of this kn
 be in use at this time, since such a construction would required a special installation
 program and SGX TA to recieve the encrypted binary, decrypt it, separate it into the
 three different elements, and then install all three. This installation is complex,
-because the Client App decrypted inside the TEE must be passed out of the TEE to an
-installer in the REE which would install the Client App; this assumes that the Client
+because the Untrusted Application decrypted inside the TEE must be passed out of the TEE to an
+installer in the REE which would install the Untrusted Application; this assumes that the Client
 App binary includes the TA code also, otherwise there is a significant problem in getting
-the SGX encalve code (the TA) from the TEE, through the installer and into the Client App
+the SGX encalve code (the TA) from the TEE, through the installer and into the Untrusted Application
 in a trusted fashion. Finally, the personalization data would need to be sent out of the
 TEE (encrypted in an SGX encalve-to-enclave manner) to the REE's installation app, which
-would pass this data to the installed Client App, which would in turn send this data
+would pass this data to the installed Untrusted Application, which would in turn send this data
 to the SGX enclave (TA). This complexity is due to the fact that each SGX enclave is separate
 and does not have direct communication to one another.
 
 [NOTE: Need to add an equivalent discussion for an ARM/TZ implementation]  
 
-## TEEP Architectural Support for Client App, TA, and Personalization Data Delivery
+## TEEP Architectural Support for Untrusted Application, TA, and Personalization Data Delivery
 This section defines TEEP support for the three different cases for delivery of the Client
 App, TA, and personalization data.
 
@@ -686,8 +686,8 @@ of the allowed TAs via consent or action of downloading.
 PKI    CA    -- CA                                 CA --
         |    |                                         |
         |    |                                         |
-        |    |                                         |
-Device  |    |   ---    Agent / Client App   ---       |
+        |    |             TEEP Agent /                |
+Device  |    |   ---  Untrusted Application  ---       |
 SW      |    |   |                             |       |
         |    |   |                             |       |
         |    |   |                             |       |
@@ -707,27 +707,27 @@ SW      |    |   |                             |       |
         |                           | <--  Get a TAM cert ------ |
         |
 1. Build two apps:
-    Client App
+   Untrusted Application
        TA
         |
         |
-   Client App -- 2a. --> | ----- 3. Install -------> |
-      TA ------- 2b. Supply ------> | 4. Messaging-->|
-        |                |          |                |
+   Untrusted Application -- 2a. --> | ----- 3. Install -------> |
+       TA ----------------- 2b. Supply ------> | 4. Messaging-->|
+        |                           |          |                |
 ~~~~
 {: #experience title="Developer Experience"}
 
 {{experience}} shows an application developer building
-two applications: 1) a rich Client Application; 2) a TA
+two applications: 1) an Untrusted Application; 2) a TA
 that provides some security functions to be run inside
 a TEE. At step 2, the application developer uploads the
-Client Application (2a) to an Application Store. The Client
+Untrusted Application (2a) to an Application Store. The Client
 Application may optionally bundle the TA binary. Meanwhile,
 the application developer may provide its TA to a TAM provider
 that will be managing the TA in various devices. 3. A user
 will go to an Application Store to download the Client
-Application. The Client Application will trigger TA installation
-by initiating communication with a TAM. This is the step 4. The Client Application
+Application. The Untrusted Application will trigger TA installation
+by initiating communication with a TAM. This is the step 4. The Untrusted Application
 will get messages from TAM, and interacts with device
 TEE via an Agent.
 
@@ -776,14 +776,13 @@ and device attestation and response messages created by a TEE that
 responds to a TAM's message.
 
 It should be noted that network communication capability is generally
-not available in TAs in today's TEE-powered devices.  The networking
-functionality must be delegated to a rich Client Application.  Client
-Applications will need to rely on an agent in the REE to interact
-with a TEE for message exchanges.  Consequently, a TAM generally
-communicates with a Client Application about how it gets messages
+not available in TAs in today's TEE-powered devices.  Trusted
+Applications need to rely on a broker in the REE to interact
+with a TEE for network message exchanges.  Consequently, a TAM generally
+communicates with an Untrusted Application about how it gets messages
 that originate from a TEE inside a device.  Similarly, a TA or TEE
-generally gets messages from a TAM via some Client Application,
-namely, a TEEP Broker in this protocol architecture, not directly
+generally gets messages from a TAM via 
+a TEEP Broker in this protocol architecture, not directly
 from the network.
 
 It is imperative to have an interoperable protocol to communicate
@@ -1011,30 +1010,30 @@ A TEE and TAs do not generally have the capability to communicate to the
 outside of the hosting device.  For example, GlobalPlatform
 {{GPTEE}} specifies one such architecture.  This calls for a software
 module in the REE world to handle the network communication.  Each
-Client Application in the REE might carry this communication functionality
+Untrusted Application in the REE might carry this communication functionality
 but such functionality must also interact with the TEE for the message exchange.  
 The TEE interaction will vary according to different TEEs.  In order for
-a Client Application to transparently support different TEEs, it is
-imperative to have a common interface for a Client Application to
+an Untrusted Application to transparently support different TEEs, it is
+imperative to have a common interface for an Untrusted Application to
 invoke for exchanging messages with TEEs.
 
 A shared module in REE comes to meet this need.  A TEEP broker is an application
 running in the REE of the device or an SDK that facilitates
 communication between a TAM and a TEE.  It also provides interfaces for
-Client Applications to query and trigger TA installation that the
+Untrusted Applications to query and trigger TA installation that the
 application needs to use.
 
-It isn't always that a Client Application directly calls such a Broker
+It isn't always that an Untrusted Application directly calls such a Broker
 to interact with a TEE. A REE Application Installer might carry out TEE
-and TAM interaction to install all required TAs that a Client Application
-depends. A Client Application may have a metadata file that describes
+and TAM interaction to install all required TAs that an Untrusted Application
+depends. An Untrusted Application may have a metadata file that describes
 the TAs it depends on and the associated TAM that each TA installation
 goes to use. The REE Application Installer can inspect the
 application metadata file and installs TAs on behalf of the Client
-Application without requiring the Client Application to run first.
+Application without requiring the Untrusted Application to run first.
 
-This interface for Client Applications or Application Installers may be
-commonly in a form of an OS service call for an REE OS.  A Client Application
+This interface for Untrusted Applications or Application Installers may be
+commonly in a form of an OS service call for an REE OS.  An Untrusted Application
 or an Application Installer interacts with the device TEE and the TAMs.
 
 ## Role of the TEEP Broker
@@ -1084,10 +1083,10 @@ multiple TEEs are present in a device, one TEEP Broker per TEE may be used.
 When only one Broker is used per device, the Broker provider is responsible
 to allow multiple TAMs and TEE providers to achieve interoperability.  With a
 standard Broker interface, each TAM can implement its own SDK for its SP
-Client Applications to work with this Broker.
+Untrusted Applications to work with this Broker.
 
 Multiple independent Broker providers can be used as long as they have
-standard interface to a Client Application or TAM SDK.  Only one
+standard interface to an Untrusted Application or TAM SDK.  Only one
 Broker is generally expected in a device.
 
 # Attestation
@@ -1367,11 +1366,11 @@ into the system.  Delivery of that TA to the TEE is then the
 responsibility of the TEE, using the security mechanisms provided by
 the protocol.
 
-We allow a way for an (untrusted) application to check the
+We allow a way for an Untrusted Application to check the
 trustworthiness of a TA.  A TEEP Broker has a function to allow an
 application to query the information about a TA.
 
-An application in the Rich O/S may perform verification of the TA by
+An Untrusted Application may perform verification of the TA by
 verifying the signature of the TA.  The GetTAInformation function is
 available to return the TEE supplied TA signer and TAM signer
 information to the application.  An application can do additional


### PR DESCRIPTION
For #55, it also removes "Client" App duplication with "Untrusted" App,
where the latter is preferred since the app may be the server
side of some protocol like HTTP, and so Client is confusing.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>