### PR TITLE
Proposed changes to depend on RATS for attestation

### DIFF
--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -1107,7 +1107,7 @@ and not all attestations are acceptable to every verifier.  A third entity (a Re
 can then use "attestation results", in the form of another series of claims, from a Verifier
 to make authorization decisions.
 
-In TEEP, as depicted in {{attestation}},
+In TEEP, as depicted in {{attestation-roles}},
 the primary purpose of an attestation is to allow a device (the Attester) to prove to TAMs
 (the Relying Parties) that a TEE in the device has particular properties, was built by a particular
 manufacturer, or is executing a particular TA. Other claims are possible; TEEP
@@ -1126,7 +1126,7 @@ of extended claims.
    | +------------+ |            +----------+  Attestation  +----------+
    +----------------+                             Result
 ~~~~
-{: #attestation title="TEEP Attestation Roles"}        
+{: #attestation-roles title="TEEP Attestation Roles"}        
 
 As of the writing of this specification, device and TEE attestations have not been standardized
 across the market. Different devices, manufacturers, and TEEs support different attestation


### PR DESCRIPTION
Align picture with diagrams used in the TEEP WG at IETF 105

THis addresses issues #17, #31, and the part of #70 that talks about
digital signature formats.  Per discussion at IETF 106, the direction is
that the architecture document should explain the relationship between
TEEP and attestation, and leave protocol details to the TEEP protocol
spec. It should NOT discuss attestation details, including anything
about signing with any attestation key, seeding of attestation keys,
or using specific crypto algorithms for attestation.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>