### PR TITLE
Minor adjustment to the text about hardware enforcement of TAs

### DIFF
--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -114,7 +114,7 @@ sensitive data. An application component running inside a TEE is referred to as 
 Trusted Application (TA), while an application running outside any TEE
 is referred to as an Untrusted Application (UA).
 
-TEEs use hardware enforcement combined with software protection to protect TAs and
+TEEs typically use hardware enforcement combined with software protection to secure TAs and
 its data, but also presents a more limited set of services to applications inside the
 TEE than is normally available to Untrusted Applications.
 

--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -114,9 +114,9 @@ sensitive data. An application component running inside a TEE is referred to as 
 Trusted Application (TA), while an application running outside any TEE
 is referred to as an Untrusted Application (UA).
 
-TEEs typically use hardware enforcement combined with software protection to secure TAs and
-its data, but also presents a more limited set of services to applications inside the
-TEE than is normally available to Untrusted Applications.
+TEEs use hardware enforcement combined with software protection to secure TAs and
+its data. TEEs typically offer a more limited set of services to TAs than is 
+normally available to Untrusted Applications.
 
 But not all TEEs are the same, and different vendors may have different
 implementations of TEEs with different security properties, different

--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -114,8 +114,8 @@ sensitive data. An application component running inside a TEE is referred to as 
 Trusted Application (TA), while an application running outside any TEE
 is referred to as an Untrusted Application (UA).
 
-The TEE typically uses hardware to enforce protections on the TA and its data, but
-also presents a more limited set of services to applications inside the
+TEEs use hardware enforcement combined with software protection to protect TAs and
+its data, but also presents a more limited set of services to applications inside the
 TEE than is normally available to Untrusted Applications.
 
 But not all TEEs are the same, and different vendors may have different


### PR DESCRIPTION
Reason: In TrustZone, for example, TAs are not directly visible at the level of the TrustZone hardware enforcement. TAs are protected by the OS running in the secure world.