### PR TITLE
Clarification on the Service Provider - TAM Relationship

### DIFF
--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -166,7 +166,7 @@ The Trusted Execution Provisioning (TEEP) protocol addresses the following probl
     between cooperating TAs under the SP's control, and specify whether
     the TAs can communicate, share data, and/or share key material.
 
-Note: The Service Provider requires the help of a TAM in order to provision
+Note: The Service Provider requires the help of a TAM to provision
 the Trusted Applications to remote devices and the TEEP protocol exchanges
 messages between a Trusted Application Manager (TAM) and a TEEP Agent via 
 a TEEP Broker. 

--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -166,6 +166,11 @@ The Trusted Execution Provisioning (TEEP) protocol addresses the following probl
     between cooperating TAs under the SP's control, and specify whether
     the TAs can communicate, share data, and/or share key material.
 
+Note: The Service Provider requires the help of a TAM in order to provision
+the Trusted Applications to remote devices and the TEEP protocol exchanges
+messages between a Trusted Application Manager (TAM) and a TEEP Agent via 
+a TEEP Broker. 
+    
 #  Terminology
 
 The following terms are used:
@@ -196,8 +201,6 @@ The following terms are used:
 
   - Service Provider (SP): An entity that wishes to provide a service
     on Devices that requires the use of one or more Trusted Applications.
-    A Service Provider requires the help of a TAM in order to provision
-    the Trusted Applications to remote devices.
 
   - Device User: A human being that uses a device. Many devices have
     a single device user. Some devices have a primary device user with


### PR DESCRIPTION
The fact that the SP needs a TAM to interact with the TEEP Agent on the device is only mentioned later. I push the text earlier in the document.