### PR TITLE
Clarifying Introduction Text

### DIFF
--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -116,7 +116,9 @@ one or more TEEs into their devices depending on market needs.
 
 To simplify the life of TA developers interacting
 with TAs in a TEE, an interoperable protocol for managing TAs running in
-different TEEs of various devices is needed. In this TEE ecosystem,
+different TEEs of various devices is needed. This software update protocol 
+needs to make sure that compatible trusted and untrusted components of an 
+application are installed on the correct device. In this TEE ecosystem,
 there often arises a need for an external trusted party to verify the
 identity, claims, and rights of TA developers, devices, and their TEEs.
 This trusted third party is the Trusted Application Manager (TAM).
@@ -151,20 +153,19 @@ the following problems:
     device's TEE is the most up-to-date version, and if not, update the
     TA in the TEE.
 
-  - A TA developer wants to remove a confidential TA from a device's TEE if
-    the TA developer is no longer offering such TAs or the TAs are
-    being revoked from a particular user (or device).  For example,
-    if a subscription or contract for a particular service has expired,
-    or a payment by the user has not been completed or has been rescinded.
+  - A Device Administrator wants to remove a TA from a device's TEE if
+    the TA developer is no longer maintaining that TA, when the TA has
+    been revoked or is not used for other reasons anymore (e.g. due to an 
+    expired subscription).
 
   - A TA developer wants to define the relationship
     between cooperating TAs under the TA developer's control, and 
     specify whether
     the TAs can communicate, share data, and/or share key material.
 
-Note: The TA developer requires the help of a TAM to provision
-the Trusted Applications to remote devices and the TEEP protocol exchanges
-messages between a TAM and a TEEP Agent via a TEEP Broker. 
+Note: The TA developer requires the help of a TAM and most likely the Device 
+Administrator to provision the Trusted Applications to remote devices and 
+the TEEP protocol exchanges messages between a TAM and a TEEP Agent via a TEEP Broker. 
     
 #  Terminology {#terminology}
 

--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -117,7 +117,7 @@ one or more TEEs into their devices depending on market needs.
 To simplify the life of TA developers interacting
 with TAs in a TEE, an interoperable protocol for managing TAs running in
 different TEEs of various devices is needed. This software update protocol 
-needs to make sure that compatible trusted and untrusted components of an 
+needs to make sure that compatible trusted and untrusted components (if any) of an 
 application are installed on the correct device. In this TEE ecosystem,
 there often arises a need for an external trusted party to verify the
 identity, claims, and rights of TA developers, devices, and their TEEs.

--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -155,7 +155,7 @@ the following problems:
 
   - A Device Administrator wants to remove a TA from a device's TEE if
     the TA developer is no longer maintaining that TA, when the TA has
-    been revoked or is not used for other reasons anymore (e.g. due to an 
+    been revoked or is not used for other reasons anymore (e.g., due to an 
     expired subscription).
 
   - A TA developer wants to define the relationship


### PR DESCRIPTION
Based on comment from Russ that 'Making sure that compatible trusted and untrusted components of an application are installed on the same device' is important as well. 

Also covers this remark:

"
   -  A TA developer wants to remove a confidential TA from a device's
      TEE if the TA developer is no longer offering such TAs or the TAs
      are being revoked from a particular user (or device).  For
      example, if a subscription or contract for a particular service
      has expired, or a payment by the user has not been completed or
      has been rescinded.

This implies that the TA developer has some of the privileges that I associate with the TAM.  Yes, I see the note at the end of the bullets, but I think this is an indication that the privileges are not quite right for these roles.  Also, if I was writing a TA for a subscription, I would have the TA perform some form of payment checking, and then refuse to decrypt the content if the payment checking fails.  Perhaps the REE passes a signed proof of payment.  This way, the TA developer does not need to actually have permission to remove a TA. Further, if the TA is on a multi-user device, removing the TA would adversely impact other users.
"