### PR TITLE
Add note about difference between requesting TA binary vs metadata

### DIFF
--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -1038,6 +1038,9 @@ the RATS Architecture {{I-D.ietf-rats-architecture}}.
 
   - Requested Components: A list of zero or more components (TAs or other dependencies needed by a TEE)
     that are requested by some depending app, but which are not currently installed in the TEE.
+    The claims also need to specify for each component, whether the TA binary
+    is needed, or whether the TA binary is already available and only
+    permission to install is needed.
 
 # Algorithm and Attestation Agility
 


### PR DESCRIPTION
Filed against teep-protocol doc in
https://github.com/ietf-teep/teep-protocol/issues/5
but it affects this bullet in the arch doc too.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>