### PR TITLE
Move much of section 3 from the transport spec to the architecture doc

### DIFF
--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -914,6 +914,42 @@ the TAM.
 
 ## TEEP Broker Implementation Consideration
 
+As depicted in {{broker-models}}, there are multiple ways in which a TEEP Broker
+can be implemented, with more or fewer layers being inside the TEE.  For example, in
+model A, the model with the smallest TEE footprint, only the TEEP implementation is inside
+the TEE, whereas the TEEP/HTTP implementation is in the TEEP Broker outside the TEE.
+
+~~~~
+                        Model:    A      B      C     ...
+
+                                 TEE    TEE    TEE
+     +----------------+           |      |      |
+     |      TEEP      |     Agent |      |      | Agent
+     | implementation |           |      |      |
+     +----------------+           v      |      |
+              |                          |      |
+     +----------------+           ^      |      |
+     |    TEEP/HTTP   |    Broker |      |      |
+     | implementation |           |      |      |
+     +----------------+           |      v      |
+              |                   |             |
+     +----------------+           |      ^      |
+     |      HTTP      |           |      |      |
+     | implementation |           |      |      |
+     +----------------+           |      |      v
+              |                   |      |
+     +----------------+           |      |      ^
+     |   TCP or QUIC  |           |      |      | Broker
+     | implementation |           |      |      |
+     +----------------+           |      |      |
+                                 REE    REE    REE
+~~~~
+{: #broker-models title="TEEP Broker Models"}
+
+In other models, additional layers are moved into the TEE, increasing the TEE footprint,
+with the Broker either containing or calling the topmost protocol layer outside of the TEE.
+An implementation is free to choose any of these models.
+
    TEEP Broker implementers should consider methods of distribution, scope and
    concurrency on devices and runtime options.
    Several non-exhaustive options are discussed below. 

--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -952,7 +952,6 @@ An implementation is free to choose any of these models.
 
    TEEP Broker implementers should consider methods of distribution, scope and
    concurrency on devices and runtime options.
-   Several non-exhaustive options are discussed below. 
 
 ### TEEP Broker APIs {#apis}
 


### PR DESCRIPTION
Addresses issue #203.
Corresponding change to the transport spec is at
https://github.com/ietf-teep/otrp-over-http/pull/25

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>