### PR TITLE
Remove Requested/Unneeded Components from claims

### DIFF
--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -1071,17 +1071,6 @@ the RATS Architecture {{I-D.ietf-rats-architecture}}.
   - Freshness Proof: A claim that includes freshness information must be included, such as a nonce
     or timestamp.
 
-  - Requested Components: A list of zero or more components (TAs or other dependencies needed by a TEE)
-    that are requested by some depending app, but which are not currently installed in the TEE.
-    The claims also need to specify for each component, whether the TA binary
-    is needed, or whether the TA binary is already available and only
-    permission to install is needed.
-
-  - Unneeded Components: A list of zero or more components (TAs or other dependencies needed by a TEE)
-    that are no longer needed by any depending application, but which are currently
-    installed in the TEE, so that the TAM can choose to remove from the TEE
-    if desired.
-
 # Algorithm and Attestation Agility
 
 RFC 7696 {{RFC7696}} outlines the requirements to migrate from one


### PR DESCRIPTION
Because they should be protocol fields.  See issue #208
and rationale posted to list with subject
"What goes in claims vs TEEP protocol fields"

Corresponding change to TEEP protocol spec is in
https://github.com/ietf-teep/teep-protocol/pull/47

Addresses #208

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>