### PR TITLE
Replace certificate chain with certificate path

### DIFF
--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -1225,16 +1225,16 @@ for protecting the resource usage allocated for Trusted Component management.
 A root CA for TAM certificates might get compromised or its certificate might
 expire, or a Trust Anchor other than a root CA certificate may also expire or
 be compromised.
-TEEs are responsible for validating the entire TAM certificate chain,
+TEEs are responsible for validating the entire TAM certificate path,
 including the TAM certificate and any intermediate certificates up to
 the root certificate.  Such validation includes checking for certificate
-revocation.
+revocation. See Section 6 of {{RFC5280}} for details.
 
-If a TAM certificate chain validation fails, the TAM
+If a TAM certificate path validation fails, the TAM
 might be rejected by a TEEP Agent.
-To address this, some certificate chain update mechanism
+To address this, some certificate path update mechanism
 is expected from TAM operators, so that the TAM can get
-a new certificate chain that can be validated by a TEEP Agent.
+a new certificate path that can be validated by a TEEP Agent.
 In addition, the Trust Anchor in the TEEP Agent's Trust Anchor Store
 may need to be updated.  To address this, some TEE Trust Anchor update 
 mechanism is expected from device OEMs.
@@ -1243,16 +1243,16 @@ Similarly,
 a root CA for TEE certificates might get compromised or its certificate might
 expire, or a Trust Anchor other than a root CA certificate may also expire or
 be compromised.
-TAMs are responsible for validating the entire TEE certificate chain,
+TAMs are responsible for validating the entire TEE certificate path,
 including the TEE certificate and any intermediate certificates up to
 the root certificate.  Such validation includes checking for certificate
 revocation.
 
-If a TEE certificate chain validation fails, the TEE
+If a TEE certificate path validation fails, the TEE
 might be rejected by a TAM, subject to the TAM's policy.
-To address this, some certificate chain update mechanism
+To address this, some certificate path update mechanism
 is expected from device OEMs, so that the TEE can get
-a new certificate chain that can be validated by a TAM.
+a new certificate path that can be validated by a TAM.
 In addition, the Trust Anchor in the TAM's Trust Anchor Store
 may need to be updated.
 


### PR DESCRIPTION
RFC 4949 says for certificate chain:
> Deprecated Term: IDOCs SHOULD NOT use this term; it duplicates the
> meaning of a standardized term. Instead, use "certification path".

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>