### PR TITLE
Update label in TEEP broker implementation diagram

### DIFF
--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -977,7 +977,7 @@ the TEE, whereas the TEEP/HTTP implementation is in the TEEP Broker outside the 
      +----------------+           |      v      |
               |                   |             |
      +----------------+           |      ^      |
-     |      HTTP      |           |      |      |
+     |     HTTP(S)    |           |      |      |
      | implementation |           |      |      |
      +----------------+           |      |      v
               |                   |      |


### PR DESCRIPTION
Change "HTTP implementation" to "HTTP(S) implementation" to imply inclusion of TLS.

Addresses #222

Signed-off-by: Dave Thaler <dthaler@microsoft.com>