### PR TITLE
Text Proposal for Data Protection

### DIFF
--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -1177,13 +1177,16 @@ from compromise by another user or tenant, even if the attacker has TAs.
 
 The protocol between TEEP Agents and TAMs similarly is responsible for
 securely providing integrity and confidentiality protection against
-adversaries between them. Since the transport protocol under the TEEP
-protocol might be implemented outside a TEE, as discussed in {{broker}},
-it cannot be relied upon for sufficient protection.  The TEEP protocol
-provides integrity protection, but confidentiality must be provided by
-payload encryption, i.e., using encrypted TA binaries and encrypted
-attestation information.  See {{I-D.ietf-teep-protocol}} for more
-discussion.
+adversaries between them. It is a design choice at what layers to best 
+provide protection against network adversaries. As discussed in {{broker}}, 
+the transport protocol and the Transport Layer Security protocol under 
+the TEEP protocol may terminate outside a TEE. If it does, the TEEP protocol 
+itself must provide integrity protection and confidentiality protection to 
+secure data end-to-end. For example, confidentiality protection for 
+payloads may be provided by utilizing encrypted TA binaries and encrypted
+attestation information. See {{I-D.ietf-teep-protocol}} for how a specific 
+solution addresses the design question of how to provide integrity and 
+confidentiality protection.
 
 ## Compromised REE {#compromised-ree}
 

--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -1179,7 +1179,7 @@ The protocol between TEEP Agents and TAMs similarly is responsible for
 securely providing integrity and confidentiality protection against
 adversaries between them. It is a design choice at what layers to best 
 provide protection against network adversaries. As discussed in {{broker}}, 
-the transport protocol and the Transport Layer Security protocol under 
+the transport protocol and any security mechanism associated with it (e.g., the Transport Layer Security protocol) under 
 the TEEP protocol may terminate outside a TEE. If it does, the TEEP protocol 
 itself must provide integrity protection and confidentiality protection to 
 secure data end-to-end. For example, confidentiality protection for 


### PR DESCRIPTION
Here is my argument for making this text change: 

I believe that the architecture document should allow for different solutions that follow certain assumptions. Of course, the architecture puts constraints on the solution space but, as outlined in various sections in the draft (such as Figure 5) there are a few options. 

The text I have modified with this PR focuses on a specific solution, namely one that follows the TEEP protocol. I do, however, believe that there will be other designs in the future that will be in the scope of the TEEP architecture document but make different design decisions. 

I believe that there is no reason why we wouldn't want to allow them as well. 
