### PR TITLE
Update to use 200902 trust boilerplate

### DIFF
--- a/draft-ietf-teep-architecture.md
+++ b/draft-ietf-teep-architecture.md
@@ -4,7 +4,7 @@ abbrev: TEEP Architecture
 docname: draft-ietf-teep-architecture-14
 category: info
 
-ipr: pre5378Trust200902
+ipr: trust200902
 area: Security
 workgroup: TEEP
 keyword: Internet-Draft


### PR DESCRIPTION
Fixes id-nits warning reported by Tiru.
This document was created after 2008 so RFC 5378 applies.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>